### PR TITLE
Added .ipynb script and ~25 lines of R code to add election dates for municipal elections.

### DIFF
--- a/code/municipality_elections/other/01_scrap_municipal_elections_dates.ipynb
+++ b/code/municipality_elections/other/01_scrap_municipal_elections_dates.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "080f9a30",
+   "metadata": {},
+   "source": [
+    "### The goal of this notebook is to scrap Google search results + parse them via Anthropic's Claude to get the date of municipal elections in each German state.\n",
+    "\n",
+    "* It extracts the title and description from the results of the following Google Search: **\"Kommunalwahlen [state] '[year]' 'am'\"** for all combinations of state and election year. See for instance: [Kommunalwahlen Brandenburg '2014' 'am'](https://www.google.de/search?q=Kommunalwahlen+Brandenburg+%272014%27+%27am%27&sei=26cGaLHbBqirkdUPw_rquQ4).\n",
+    "  \n",
+    "* It asks [Anthropic's Claude](https://www.anthropic.com/claude) to parse the resulting output and to extract the date in YYYY-MM-DD format. As of 21/04/2025, using the API for Claude 3.7 Sonnet, it costs about $0.45. [Naturally, any other LLM could be used, but the author of the script got free credits from Anthropic :-)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92fc1633",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install necessary libraries if not already installed ; ideally, we should have a requirements.txt file \n",
+    "# But this script is very auxilliary to the main codebase, so leaving it as it is for now to keep it simple\n",
+    "\n",
+    "# !pip install pandas googlesearch-python anthropic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad5b6333",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from googlesearch import search\n",
+    "from pathlib import Path\n",
+    "import time\n",
+    "\n",
+    "import anthropic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fea446d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PATH = str(Path.cwd().resolve().parents[2]) \n",
+    "\n",
+    "client = anthropic.Client(api_key=os.getenv(\"ANTHROPIC_API_KEY\")) # Set your Anthropic API key as an environment variable\n",
+    "MODEL = \"claude-3-7-sonnet-latest\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b27e5258",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_election_date(text_snippet: str, state: str, year: int) -> str:\n",
+    "    \"\"\"Uses an LLM to extract the municipal election date from text.\"\"\"\n",
+    "    \n",
+    "    if not text_snippet or not client.api_key:\n",
+    "        print(\"Warning: No text snipppt or API key provided\")\n",
+    "        return \"NULL\"\n",
+    "\n",
+    "    prompt = f\"\"\"\n",
+    "    From the provided Google search result snippets relating to Kommunalwahlen (municipal elections) in the German state '{state}' for the year {year}, extract the main election date.\n",
+    "\n",
+    "    Search Result Snippets:\n",
+    "    ---\n",
+    "    {text_snippet}\n",
+    "    ---\n",
+    "\n",
+    "    Return only the single, most likely main election date. Format the date strictly as YYYY-MM-DD.\n",
+    "    Do not include run-off dates (Stichwahl) or publication dates of the snippets.\n",
+    "    If no specific date is found, return the exact string 'NULL'.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        message = client.messages.create(\n",
+    "            model=MODEL,\n",
+    "            max_tokens=50,\n",
+    "            messages=[{\"role\": \"user\", \"content\": prompt}]\n",
+    "        )\n",
+    "        if message.content and isinstance(message.content, list) and message.content[0].text:\n",
+    "             result = message.content[0].text.strip()\n",
+    "             return result\n",
+    "        else:\n",
+    "            print(f\"Warning: LLM returned unexpected content for {state} {year}\")\n",
+    "            return \"NULL\"\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error calling LLM API for {state} {year}: {e}\")\n",
+    "        return \"NULL\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e79edde2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_text_from_search(state: str, year: int, num_search_results=10) -> str:\n",
+    "    \"\"\"\n",
+    "    Extract title + description from Google search results for a given state and year. \n",
+    "\n",
+    "    Args:\n",
+    "        state: The name of the German state.\n",
+    "        year: The election year.\n",
+    "        num_search_results: How many Google results to fetch.\n",
+    "\n",
+    "    Returns:\n",
+    "        A single string containing titles and descriptions from search results,\n",
+    "        or an empty string if search fails or yields no results.\n",
+    "    \"\"\"\n",
+    "    search_term = f\"Kommunalwahlen {state} '{year}' 'am'\" \n",
+    "    print(f\"Searching for: '{search_term}'\")\n",
+    "    snippets = []\n",
+    "    try:\n",
+    "        search_generator = search(\n",
+    "            search_term,\n",
+    "            num_results=num_search_results,\n",
+    "            lang=\"de\", \n",
+    "            advanced=True, \n",
+    "            sleep_interval=1 \n",
+    "        )\n",
+    "\n",
+    "        for result in search_generator:\n",
+    "            title = result.title if result.title else \"\"\n",
+    "            desc = result.description if result.description else \"\"\n",
+    "            if title or desc: \n",
+    "                 snippets.append(f\"Title: {title}\\nDescription: {desc}\")\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error during search for {state} {year}: {e}\")\n",
+    "        return \"\" \n",
+    "\n",
+    "    return \"\\n---\\n\".join(snippets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92cf8a1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def main():\n",
+    "\n",
+    "    # df_combinations contains all the possible combinations of state names x election years as outputted by `code/municipality_elections/01_municipal_unharm.R`.\n",
+    "    df_combinations = pd.read_csv(PATH + \"/data/municipal_elections/processed/municipal_elections_combinations.csv\")\n",
+    "    \n",
+    "    try:\n",
+    "        df_with_dates = pd.read_csv(PATH + \"/data/municipal_elections/processed/municipal_elections_dates.csv\")\n",
+    "    except FileNotFoundError:\n",
+    "        df_with_dates = None\n",
+    "    \n",
+    "    if df_with_dates:\n",
+    "        df_combinations = df_combinations[~df_combinations.set_index(['state', 'election_year']).index.isin(df_with_dates.set_index(['state', 'election_year']).index)]\n",
+    "        print(f\"Filtered out {len(df_combinations)} combinations that already have dates.\")\n",
+    "\n",
+    "    n_to_process = len(df_combinations)\n",
+    "\n",
+    "    n_processed = 0\n",
+    "    results = []\n",
+    "\n",
+    "    for index, row in df_combinations.iterrows():\n",
+    "        state = row['state']\n",
+    "        year = row['election_year']\n",
+    "\n",
+    "        search_content = get_text_from_search(state, year)\n",
+    "\n",
+    "        if search_content:\n",
+    "            extracted_date = extract_election_date(search_content, state, year)\n",
+    "        else:\n",
+    "            print(\"  -> No search content found, skipping LLM.\")\n",
+    "            extracted_date = \"SEARCH_FAILED\" \n",
+    "\n",
+    "        results.append({\n",
+    "            'state': state,\n",
+    "            'year': year,\n",
+    "            'extracted_date': extracted_date\n",
+    "        })\n",
+    "\n",
+    "        time.sleep(1)\n",
+    "        n_processed += 1\n",
+    "        print(f\"Processed {n_processed}/{n_to_process} combinations.\") if n_processed % 10 == 0 else None        \n",
+    "\n",
+    "    # convert results to DataFrame\n",
+    "    df_results = pd.DataFrame(results)\n",
+    "    if df_with_dates:\n",
+    "        df_results = pd.concat([df_with_dates, df_results], ignore_index=True)\n",
+    "        print(f\"Combined with existing dates, total rows: {len(df_results)}\")\n",
+    "    else: \n",
+    "        print(f\"New DataFrame created, total rows: {len(df_results)}\")\n",
+    "        \n",
+    "    # save to CSV\n",
+    "    output_path = PATH + \"/data/municipal_elections/processed/municipal_elections_dates.csv\"\n",
+    "    df_results.to_csv(output_path, index=False)\n",
+    "    print(f\"Results saved to {output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64caecde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    main()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c958983d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = pd.read_csv(PATH + \"/data/municipal_elections/processed/municipal_elections_dates.csv\")\n",
+    "# Check for NULL or incorrect dates\n",
+    "dates.loc[(dates['extracted_date'] == 'NULL') | (dates['extracted_date'].str[:4] != dates['year'].astype(str))]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data/municipal_elections/processed/municipal_elections_combinations.csv
+++ b/data/municipal_elections/processed/municipal_elections_combinations.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e45507e7cf4197eac58e2c68807dce4420a6a68efc693f0e018d4208e40d2f5c
+size 2023

--- a/data/municipal_elections/processed/municipal_elections_dates.csv
+++ b/data/municipal_elections/processed/municipal_elections_dates.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e93dc363e1d137b3c79294161d9c9458bcd1e6a5309fed21b0b3a173c379d27
+size 3260


### PR DESCRIPTION
1. Added a Jupyter notebook that scraps Google search results and parses the output with a LLM to extract the election date for municipal elections for all existing combinations of state/lander name + election date. **This relies on the assumption that all municipal elections within a lander for a given year take place on the same day.** 

2. Modified the R script `01_municipal_unharm.R` so that it outputs an intermediary CSV file that contains the combinations of state names and election years + so that it imports back the results of the scraping process and adds them to the main dataframe. Since the harmonization in `02_municipal_harm.R` is based on an import of the data produced by `01_municipal_unharm.R`, this should thus apply the changes to both datasets once the two scripts have been run. 

3. Ran the scraping & parsing + the R script and stored the two intermediary dataframes (combinations of state + election year with and without scraped dates) in `data/municipal_elections/processed/`. 

**Important: There are four municipal elections that have missing `election_year` values at the end of this process:** 
* 15086055 in 2005
* 15087275 in 2005
* 15088195 in 2006
* 15088235 in 2006

I don't really know why and since I don't speak German, it's hard for me to investigate :-) 

I would also recommend that someone who knows more about German elections than I do checks that the result of the scraping + parsing is correct (contained in `municipal_elections_dates.csv`) , although I am pretty confident that it is. 